### PR TITLE
Fixes issue with unnecessary hammers.

### DIFF
--- a/backbone.hammer.js
+++ b/backbone.hammer.js
@@ -33,13 +33,17 @@
   };
 
   _.extend(Backbone.View.prototype, protoProps, {
+    _hammered: false,
+
     undelegateEvents: function(){
       this.undelegateHammerEvents();
       return undelegateEvents.apply(this, arguments);
     },
 
     undelegateHammerEvents: function(){
-      this.hammer().off('.hammerEvents' + this.cid);
+      if (this._hammered) {
+        this.hammer().off('.hammerEvents' + this.cid);
+      }
       return this;
     },
 
@@ -72,6 +76,7 @@
     },
 
     hammer: function(options){
+      this._hammered = true;
       return this.$el.hammer(options);
     }
   });

--- a/test/unit.js
+++ b/test/unit.js
@@ -50,6 +50,35 @@ jQuery(function($){
     hammerStub.restore();
   });
 
+  test('#undelegateHammerEvents doest create hammer unless it is needed', 1, function() {
+    var view = new Backbone.View();
+    var hammerSpy = sinon.spy(view, 'hammer');
+
+    view.undelegateHammerEvents();
+    equal(hammerSpy.callCount, 0);
+    hammerSpy.restore();
+  });
+
+  test('#undelegateHammerEvents calls off when hammered', 2, function() {
+    var View = Backbone.View.extend({
+      hammerEvents: {
+        'tap': $.noop
+      }
+    });
+    var offStub = sinon.stub();
+    var hammerStub = sinon.stub(View.prototype, 'hammer');
+    hammerStub.returns({
+      on: $.noop,
+      off: offStub
+    });
+
+    var view = new View();
+    view._hammered = true;
+    view.undelegateHammerEvents();
+    ok(hammerStub.called, "hammerStub Called");
+    ok(offStub.calledWith('.hammerEvents' + view.cid), "offStub Called With");
+  });
+
   test('hammerEvents are mixed in from the constructor', function(){
     var view = new Backbone.View({
       hammerEvents: {


### PR DESCRIPTION
Hi,
I noticed after I started using _backbone.hammer.js_ that all elements that had a Backbone View attached to them had some weird style attribute added. 

``` html
style=-"webkit-user-select: none; -webkit-user-drag: none; -webkit-tap-highlight-color: rgba(0, 0, 0, 0);"`.
```

After some digging I found that `undelegateHammerEvents` calls the `hammer` function even when no **hammerEvents** exist on the view (which creates hammer on _this.$el_).

I solved it as simple I could think of by just adding a boolean to keep track if the hammer have been created by the `delegateHammerEvents` call.

If you rather not use an extra property I guess we could always change it to: 

``` js
if ('hammer' in this.$el.data()) {
  ...
}
```

but I reasoned (without measuring) that a boolean is performance-wise better. 
