### PR TITLE
allow hammerOptions to be specified as the result of a function

### DIFF
--- a/backbone.hammer.js
+++ b/backbone.hammer.js
@@ -51,7 +51,7 @@
     },
 
     delegateHammerEvents: function(events){
-      var options = _.defaults(this.hammerOptions || {}, Backbone.hammerOptions);
+      var options = _.defaults(_.result(this, 'hammerOptions') || {}, Backbone.hammerOptions);
       if (!(events || (events = _.result(this, 'hammerEvents')))) return this;
       this.undelegateHammerEvents();
       for(var key in events) {


### PR DESCRIPTION
I thought it would be useful in some cases for `hammerOptions` to be the result of a function, as can `hammerEvents`
