### PR TITLE
Remove second undelegation of hammer events

### DIFF
--- a/backbone.hammer.js
+++ b/backbone.hammer.js
@@ -53,7 +53,6 @@
     delegateHammerEvents: function(events){
       var options = _.defaults(_.result(this, 'hammerOptions') || {}, Backbone.hammerOptions);
       if (!(events || (events = _.result(this, 'hammerEvents')))) return this;
-      this.undelegateHammerEvents();
       for(var key in events) {
         var method = events[key];
         if (!_.isFunction(method)) method = this[events[key]];


### PR DESCRIPTION
Second undelegation of hammer events is not necessary.

Every invocation of `delegateEvents` invokes `Backbone.View::delegateEvents` which in turn invokes `undelegateEvents`, undelegating all hammerEvents.

Calling `undelegateHammerEvents` in `delegateHammerEvents` could still be necessary when `undelegateHammerEvents` is invoked directly - which i guess it never should.
